### PR TITLE
Use new FetchSelectedOptions in onRecord/s to skip redundant fetch

### DIFF
--- a/grist/browser/api.py
+++ b/grist/browser/api.py
@@ -34,7 +34,12 @@ class Grist:
 
     async def fetch_selected_record(self, row_id=None):
         if row_id is None:
-            row_id = (await self.raw.getCurrentRecord())["id"]
+            record = await self.raw.getCurrentRecord()
+            if record is None:
+                raise Exception(
+                    "No record is currently selected - ensure that the notebook widget is linked to (selecting by) another widget"
+                )
+            row_id = record["id"]
         return decode_record(
             await self.raw.fetchSelectedRecord(row_id, keepEncoded=True)
         )

--- a/grist/browser/comlink.py
+++ b/grist/browser/comlink.py
@@ -18,9 +18,7 @@ class ComlinkProxy:
 
     async def __call__(self, *args, **kwargs):
         if any(callable(arg) for arg in args):
-            assert (
-                len(args) == 1 and not kwargs
-            ), "Only one argument is supported for callbacks"
+            assert len(args) == 1, "Only one argument is supported for callbacks"
             [callback] = args
 
             async def wrapper(*callback_args):
@@ -31,7 +29,8 @@ class ComlinkProxy:
 
             js._grist_tmp1 = self._proxy
             js._grist_tmp2 = js.Comlink.proxy(create_proxy(wrapper))
-            result = await js.eval("_grist_tmp1(_grist_tmp2)")
+            js._grist_tmp3 = to_js(kwargs, dict_converter=js.Object.fromEntries)
+            result = await js.eval("_grist_tmp1(_grist_tmp2, _grist_tmp3)")
         else:
             args = [to_js(arg, dict_converter=js.Object.fromEntries) for arg in args]
             kwargs = {


### PR DESCRIPTION
This is a performance optimization which may or may not be significant, so it's not particularly important, it's just an itch I wanted to scratch. It make use of the new options in https://github.com/gristlabs/grist-core/commit/4e67c679b21400de3ea5887c95e86ed2ec4ceba8. Before this, when triggering the `on_records` callback, the initial payload of records (which had been painstakingly transposed and decoded) was immediately discarded in favour of `fetch_selected_table` which had the `keepEncoded` option. The behaviour should be unchanged.

Along the way I ran into a confusing error about NoneType not being subscriptable, and had to dig deep to see that it was because I'd forgotten to link the notebook to another widget. Now a more helpful error is raised.